### PR TITLE
Allow frontend app groups to utilize Procfile

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -45,6 +45,11 @@ api = "0.7"
     version = "0.12.2"
 
   [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.6.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.5.0"
@@ -81,6 +86,11 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/nginx"
     version = "0.12.2"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.6.0"
 
   [[order.group]]
     id = "paketo-buildpacks/environment-variables"
@@ -125,6 +135,11 @@ api = "0.7"
     version = "0.7.3"
 
   [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.6.0"
+
+  [[order.group]]
     id = "paketo-buildpacks/environment-variables"
     optional = true
     version = "4.5.0"
@@ -161,6 +176,11 @@ api = "0.7"
   [[order.group]]
     id = "paketo-buildpacks/httpd"
     version = "0.7.3"
+
+  [[order.group]]
+    id = "paketo-buildpacks/procfile"
+    optional = true
+    version = "5.6.0"
 
   [[order.group]]
     id = "paketo-buildpacks/environment-variables"

--- a/integration/npm_frontend_test.go
+++ b/integration/npm_frontend_test.go
@@ -83,6 +83,13 @@ func testNPMFrontend(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using optional utility buildpacks", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: nginx -p $PWD -c nginx.conf -g 'pid /tmp/server.pid;'"), os.ModePerm)).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Remove(filepath.Join(source, "Procfile"))).To(Succeed())
+			})
+
 			it("creates a working OCI image and uses utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
@@ -102,15 +109,15 @@ func testNPMFrontend(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Install")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Nginx Server")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Apache HTTP Server")))
-				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
 
-				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.
@@ -260,6 +267,13 @@ func testNPMFrontend(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using optional utility buildpacks", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: httpd -f /workspace/httpd.conf -k start -DFOREGROUND"), os.ModePerm)).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Remove(filepath.Join(source, "Procfile"))).To(Succeed())
+			})
+
 			it("creates a working OCI image and uses utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
@@ -279,15 +293,15 @@ func testNPMFrontend(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for NPM Install")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Apache HTTP Server")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Nginx Server")))
-				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
 
-				Expect(image.Buildpacks[6].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[6].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.

--- a/integration/yarn_frontend_test.go
+++ b/integration/yarn_frontend_test.go
@@ -84,6 +84,13 @@ func testYarnFrontend(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using optional utility buildpacks", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: nginx -p $PWD -c nginx.conf -g 'pid /tmp/server.pid;'"), os.ModePerm)).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Remove(filepath.Join(source, "Procfile"))).To(Succeed())
+			})
+
 			it("creates a working OCI image and uses utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
@@ -104,15 +111,15 @@ func testYarnFrontend(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Yarn Install")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Nginx Server")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Apache HTTP Server")))
-				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
 
-				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.
@@ -258,6 +265,13 @@ func testYarnFrontend(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when using optional utility buildpacks", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(filepath.Join(source, "Procfile"), []byte("web: httpd -f /workspace/httpd.conf -k start -DFOREGROUND"), os.ModePerm)).To(Succeed())
+			})
+			it.After(func() {
+				Expect(os.Remove(filepath.Join(source, "Procfile"))).To(Succeed())
+			})
+
 			it("creates a working OCI image and uses utility buildpacks", func() {
 				var err error
 				var logs fmt.Stringer
@@ -278,15 +292,15 @@ func testYarnFrontend(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Yarn Install")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Node Run Script")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Apache HTTP Server")))
+				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Procfile")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Environment Variables")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Image Labels")))
 				Expect(logs).To(ContainLines(ContainSubstring("Buildpack for Watchexec")))
 
 				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Nginx Server")))
-				Expect(logs).NotTo(ContainLines(ContainSubstring("Buildpack for Procfile")))
 
-				Expect(image.Buildpacks[7].Key).To(Equal("paketo-buildpacks/environment-variables"))
-				Expect(image.Buildpacks[7].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
+				Expect(image.Buildpacks[8].Key).To(Equal("paketo-buildpacks/environment-variables"))
+				Expect(image.Buildpacks[8].Layers["environment-variables"].Metadata["variables"]).To(Equal(map[string]interface{}{"SOME_VARIABLE": "some-value"}))
 				Expect(image.Labels["some-label"]).To(Equal("some-value"))
 
 				container, err = docker.Container.Run.


### PR DESCRIPTION
Closes https://github.com/paketo-buildpacks/web-servers/issues/132

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Use Cases
See issue

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
